### PR TITLE
chore: upgrade targetSdkVersion

### DIFF
--- a/packages/harness/renative.json
+++ b/packages/harness/renative.json
@@ -169,7 +169,7 @@
         "androidtv": {
             "engine": "engine-rn-tvos",
             "reactNativeEngine": "hermes",
-            "targetSdkVersion": 30,
+            "targetSdkVersion": 31,
             "compileSdkVersion": 31,
             "enableAndroidX": true,
             "gradle.properties": {
@@ -177,6 +177,7 @@
                 "android.enableJetifier": true,
                 "android.useAndroidX": true,
                 "android.debug.obsoleteApi": true,
+                "android:exported": true,
                 "org.gradle.jvmargs": "-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8",
                 "org.gradle.daemon": true,
                 "org.gradle.parallel": true,

--- a/packages/template/renative.json
+++ b/packages/template/renative.json
@@ -176,7 +176,7 @@
         "androidtv": {
             "engine": "engine-rn-tvos",
             "reactNativeEngine": "hermes",
-            "targetSdkVersion": 30,
+            "targetSdkVersion": 31,
             "compileSdkVersion": 31,
             "enableAndroidX": true,
             "gradle.properties": {
@@ -184,6 +184,7 @@
                 "android.enableJetifier": true,
                 "android.useAndroidX": true,
                 "android.debug.obsoleteApi": true,
+                "android:exported": true,
                 "org.gradle.jvmargs": "-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8",
                 "org.gradle.daemon": true,
                 "org.gradle.parallel": true,


### PR DESCRIPTION
Closes https://github.com/flexn-io/prd-flexn/issues/927

Tried to fix `[!] Google Api Error: Invalid request - Your app currently targets API level 30 and must target at least API level 31`. on https://github.com/flexn-io/flexn-private/actions/runs/4139564554/jobs/7157273638 but now getting 

```
 [ error ] [build] COMMAND:

./gradlew bundleRelease -x bundleReleaseJsAndAssets

FAILED with ERROR:

1: Task failed with an exception.
-----------
* Where:
Build file '/Users/pauliusguzas/Desktop/flexn/flexn/packages/harness/platformBuilds/harness_androidtv/app/build.gradle' line: 156
* What went wrong:
A problem occurred evaluating project ':app'.
2: Task failed with an exception.
-----------
* Where:
Script '/Users/pauliusguzas/Desktop/flexn/flexn/node_modules/react-native-tvos/react.gradle' line: 95
* What went wrong:
A problem occurred configuring project ':app'.
```
