### PR TITLE
metro-cache fix, missing plugins

### DIFF
--- a/packages/template/renative.template.json
+++ b/packages/template/renative.template.json
@@ -4,7 +4,8 @@
         "packageTemplate": {
             "devDependencies": {
                 "typescript": "4.9.5",
-                "@types/react": "18.2.6"
+                "@types/react": "18.2.6",
+                "@flexn/plugins": "1.0.8"
             }
         }
     },


### PR DESCRIPTION
#91 issue, metro cache is not present and will sometimes fail the build. Will update build-hooks to dynamically update that version on releases