### PR TITLE
Fix: Remove last focused view from recycler if view was unmouted

### DIFF
--- a/packages/app-harness/src/navigation/index.tsx
+++ b/packages/app-harness/src/navigation/index.tsx
@@ -18,6 +18,7 @@ import Grid from '../screens/grid';
 import ScrollToTop from '../screens/scrollToTop';
 import ComplexTabs from '../screens/complexTabs';
 import HideAllElements from '../screens/hideAllElements';
+import DynamicRows from '../screens/dynamicRows';
 
 const RootStack = createNativeStackNavigator();
 
@@ -42,6 +43,7 @@ const Navigation = () => {
                 <RootStack.Screen name="ScrollToTop" component={ScrollToTop} />
                 <RootStack.Screen name="ComplexTabs" component={ComplexTabs} />
                 <RootStack.Screen name="HideAllElements" component={HideAllElements} />
+                <RootStack.Screen name="DynamicRows" component={DynamicRows} />
             </RootStack.Navigator>
         </NavigationContainer>
     );

--- a/packages/app-harness/src/screens/dynamicRows.tsx
+++ b/packages/app-harness/src/screens/dynamicRows.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { View, FlashList, Pressable, Image, CreateListRenderItemInfo } from '@flexn/create';
+import Screen from './screen';
+import { Ratio } from '../utils';
+
+const kittyNames = ['Abby', 'Angel', 'Annie', 'Baby', 'Bailey', 'Bandit'];
+
+function interval(min = 0, max = kittyNames.length - 1) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+function generateData(width: number, height: number, items = 30) {
+    const temp: any = [];
+    for (let index = 0; index < items; index++) {
+        temp.push({
+            index,
+            backgroundImage: `https://placekitten.com/${width}/${height}`,
+            title: `${kittyNames[interval()]} ${kittyNames[interval()]} ${kittyNames[interval()]}`,
+        });
+    }
+
+    return temp;
+}
+
+const DynamicRows = () => {
+    const [data] = useState(generateData(200, 200, 3));
+    const [data2, setData2] = useState(generateData(200, 200, 3));
+
+    const rowRenderer = ({ item, focusRepeatContext }: CreateListRenderItemInfo<any>) => {
+        return (
+            <Pressable
+                style={styles.packshot}
+                focusRepeatContext={focusRepeatContext}
+                focusOptions={{
+                    animator: {
+                        type: 'border',
+                        focus: {
+                            borderColor: 'blue',
+                            borderWidth: 5,
+                        },
+                    },
+                }}
+                onPress={() => {
+                    setData2(generateData(interval(201, 210), interval(201, 210), interval(3, 10)));
+                }}
+            >
+                <Image source={{ uri: item.backgroundImage }} style={styles.image} />
+            </Pressable>
+        );
+    };
+
+    const rowRenderer2 = ({ item, focusRepeatContext }: CreateListRenderItemInfo<any>) => {
+        return (
+            <Pressable
+                style={styles.packshot}
+                focusRepeatContext={focusRepeatContext}
+                focusOptions={{
+                    animator: {
+                        type: 'border',
+                        focus: {
+                            borderColor: 'blue',
+                            borderWidth: 5,
+                        },
+                    },
+                }}
+            >
+                <Image source={{ uri: item.backgroundImage }} style={styles.image} />
+            </Pressable>
+        );
+    };
+
+    return (
+        <Screen style={{ backgroundColor: '#222222' }}>
+            <View style={{ top: Ratio(200), width: '100%', left: 50 }}>
+                <FlashList
+                    // key={data2}
+                    data={data}
+                    renderItem={rowRenderer}
+                    horizontal
+                    type="row"
+                    estimatedItemSize={Ratio(200)}
+                    style={{ height: Ratio(300) }}
+                    focusOptions={{
+                        autoLayoutScaleAnimation: true,
+                        autoLayoutSize: 50,
+                    }}
+                />
+            </View>
+            <View style={{ top: Ratio(100), width: '100%', left: 50 }}>
+                <FlashList
+                    // key={data2.length}
+                    data={data2}
+                    renderItem={rowRenderer2}
+                    horizontal
+                    type="row"
+                    estimatedItemSize={Ratio(200)}
+                    style={{ height: Ratio(300) }}
+                    focusOptions={{
+                        autoLayoutScaleAnimation: true,
+                        autoLayoutSize: 50,
+                    }}
+                />
+            </View>
+        </Screen>
+    );
+};
+
+const styles = StyleSheet.create({
+    packshot: {
+        width: Ratio(200),
+        height: Ratio(200),
+        // borderColor: 'red',
+        // borderWidth: 1,
+        marginHorizontal: Ratio(15),
+        // marginVertical: Ratio(50),
+        // borderWidth: 2,
+        // top: 100,
+    },
+    image: {
+        width: '100%',
+        height: '100%',
+    },
+});
+
+export default DynamicRows;

--- a/packages/app-harness/src/testsList.ts
+++ b/packages/app-harness/src/testsList.ts
@@ -14,8 +14,15 @@ import grid from './screens/grid';
 import scrollToTop from './screens/scrollToTop';
 import complexTabs from './screens/complexTabs';
 import hideAllElements from './screens/hideAllElements';
+import dynamicRows from './screens/dynamicRows';
 
 const testsList = [
+    {
+        component: dynamicRows,
+        title: 'Dynamic rows',
+        route: 'DynamicRows',
+        platform: ['androidtv', 'firetv', 'tvos', 'tizen', 'webos'],
+    },
     {
         component: hideAllElements,
         title: 'Hide All Elements',

--- a/packages/create/src/focusManager/model/view.ts
+++ b/packages/create/src/focusManager/model/view.ts
@@ -111,6 +111,13 @@ class View extends FocusModel {
     private _onUnmount() {
         CoreManager.removeFocusAwareComponent(this);
         this.getScreen()?.onViewRemoved(this);
+        if (this.getParent() instanceof Row || this.getParent() instanceof Grid) {
+            const parent = this.getParent() as Recycler;
+            if (parent.getFocusedView()?.getId() === this.getId()) {
+                parent.setFocusedView(null);
+                parent.setFocusedIndex(-1);
+            }
+        }
         this.unsubscribeEvents();
     }
 


### PR DESCRIPTION
Fix for https://github.com/flexn-io/create/issues/120
If recycler had focus and data in recycled changed, last focused position from recycler were not removed causing unnecessary remote events to reclaim focus in recycler

![CleanShot2023-07-07at22 19 08](https://github.com/flexn-io/create/assets/16107073/c5595461-5cc7-41d7-a745-776cd912f331)
