### PR TITLE
fix: rnw mouse, hover, accessibilityLevel types

### DIFF
--- a/packages/create/src/focusManager/types.ts
+++ b/packages/create/src/focusManager/types.ts
@@ -9,6 +9,7 @@ import type {
     ColorValue,
     View as RNView,
 } from 'react-native';
+import type { MouseEvent, PointerEvent } from 'react';
 import type { FlashListProps as FLProps, ListRenderItemInfo } from '@flexn/shopify-flash-list';
 
 import FocusModel from './model/abstractFocusModel';
@@ -113,7 +114,17 @@ export type RecyclableListFocusOptions = {
     autoLayoutSize?: number;
 };
 
-export interface ViewProps extends RNViewProps {
+type MouseEvents = {
+    onMouseDown?: (e: MouseEvent) => void;
+    onMouseEnter?: (e: MouseEvent) => void;
+    onMouseLeave?: (e: MouseEvent) => void;
+    onMouseMove?: (e: MouseEvent) => void;
+    onMouseOver?: (e: MouseEvent) => void;
+    onMouseOut?: (e: MouseEvent) => void;
+    onMouseUp?: (e: MouseEvent) => void;
+};
+
+export interface ViewProps extends RNViewProps, MouseEvents {
     focusOptions?: {
         group?: string;
         focusKey?: string;
@@ -140,7 +151,7 @@ export interface ViewGroupProps extends RNViewProps {
     ref?: React.ForwardedRef<RNView> | React.MutableRefObject<RNView>;
 }
 
-export interface PressableProps extends RNPressableProps {
+export interface PressableProps extends RNPressableProps, MouseEvents {
     focus?: boolean;
     focusOptions?: PressableFocusOptions;
     focusContext?: FocusContext;
@@ -150,8 +161,8 @@ export interface PressableProps extends RNPressableProps {
     onFocus?: () => void;
     className?: string;
     style?: ViewProps['style'];
-    onHoverIn?: null | ((event: MouseEvent) => void) | undefined;
-    onHoverOut?: null | ((event: MouseEvent) => void) | undefined;
+    onHoverIn?: (e: PointerEvent) => void;
+    onHoverOut?: (e: PointerEvent) => void;
 }
 
 export interface TouchableOpacityProps extends RNTouchableOpacityProps {

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -65,3 +65,11 @@ export {
     RemoteHandlerCallback,
     ClassRemoteHandlerCallback,
 } from './remoteHandler';
+
+// Type declarations
+import 'react-native';
+declare module 'react-native' {
+    interface AccessibilityProps {
+        accessibilityLevel?: number;
+    }
+}


### PR DESCRIPTION
#128
Adds RNW `onMouse*` types, corrects `Pressable`'s hover types, expands `AccessibilityProps` to include `accessibilityLevel`.

Can be tested by opening app-harness in VSCode and making sure the added props get autocompleted / don't show up as errors.