### PR TITLE
fix: remove uneeded code from configs

### DIFF
--- a/packages/app-harness/wdio.conf.cjs
+++ b/packages/app-harness/wdio.conf.cjs
@@ -3,7 +3,6 @@ const path = require('path');
 
 let customCapabilities = {};
 if (fs.existsSync(path.join(__dirname, '../../../wdio.capabilities.harness.js'))) {
-    // eslint-disable-next-line global-require
     const { capabilities } = require('../../../wdio.capabilities.harness');
     customCapabilities = capabilities;
 }

--- a/packages/template-starter/wdio.conf.cjs
+++ b/packages/template-starter/wdio.conf.cjs
@@ -3,7 +3,6 @@ const path = require('path');
 
 let customCapabilities = {};
 if (fs.existsSync(path.join(__dirname, '../../../wdio.capabilities.template.js'))) {
-    // eslint-disable-next-line global-require
     const { capabilities } = require('../../../wdio.capabilities.template');
     customCapabilities = capabilities;
 }
@@ -233,9 +232,6 @@ exports.config = {
                         }),
                         ...(process.env.PLATFORM === 'androidtv' && {
                             port: 3004,
-                        }),
-                        ...(process.env.PLATFORM === 'macos' && {
-                            port: 3005,
                         }),
                     },
                 },


### PR DESCRIPTION
While writing docs on graybox found some mistakes in wdio configs, this PR fixes them