### PR TITLE
fix postinstall script on linux

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -9,7 +9,7 @@
         "clean": "rm -rf ./lib && rm -rf tsconfig.tsbuildinfo",
         "compile": "tsc -b tsconfig.json",
         "watch": "tsc --watch --preserveWatchOutput",
-        "postinstall": "sh tools/overrideRNScrollView.sh"
+        "postinstall": "bash tools/overrideRNScrollView.sh"
     },
     "files": [
         "lib",

--- a/packages/create/tools/overrideRNScrollView.sh
+++ b/packages/create/tools/overrideRNScrollView.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -10,13 +10,13 @@ MIN_RN_VERSION="68"
 echo "${RN_DIR}/package.json"
 
 if [ -e "${RN_DIR}/package.json" ] ; then 
-  PACKAGE_VERSION=$(cat ${RN_DIR}/package.json \
+  PACKAGE_VERSION=$(cat "${RN_DIR}"/package.json \
     | grep version \
     | head -1 \
     | awk -F: '{print $2 }' \
     | sed 's/[",]//g')
 
-  if [ -e $RN_SCROLLVIEW_DIR ] && [ "${PACKAGE_VERSION:3:2}" -ge "${MIN_RN_VERSION}" ] ; then
+  if [ -e "$RN_SCROLLVIEW_DIR" ] && [ "${PACKAGE_VERSION:3:2}" -ge "${MIN_RN_VERSION}" ] ; then
       sed -i '' "s|'RCTScrollView'|Platform.isTV \&\& Platform.OS === 'android' ? 'RCTScrollViewTV' : 'RCTScrollView'|" "${RN_SCROLLVIEW_DIR}/ScrollViewNativeComponent.js"
       echo "Overriding done."
   else

--- a/packages/create/tools/overrideRNScrollView.sh
+++ b/packages/create/tools/overrideRNScrollView.sh
@@ -7,8 +7,6 @@ RN_DIR="${CREATE_DIR}/../../../react-native"
 RN_SCROLLVIEW_DIR="${RN_DIR}/Libraries/Components/ScrollView"
 MIN_RN_VERSION="68"
 
-echo "${RN_DIR}/package.json"
-
 if [ -e "${RN_DIR}/package.json" ] ; then 
   PACKAGE_VERSION=$(cat "${RN_DIR}"/package.json \
     | grep version \


### PR DESCRIPTION
- calling it with `sh` means it's using shell and ignoring the bash shebang from the top of the file. `-o pipefail` is a bash feature.
- #!/usr/bin/env bash is preffered instead of #!/bin/bash