### PR TITLE
Fix elements measuring after animations

### DIFF
--- a/packages/app-harness/src/screens/tests/index.ts
+++ b/packages/app-harness/src/screens/tests/index.ts
@@ -16,6 +16,7 @@ import complexTabs from './complexTabs';
 import hideAllElements from './hideAllElements';
 import dynamicRows from './dynamicRows';
 import remoteHandler from './remoteHandler';
+import measureWithAnimations from './measureWithAnimations';
 
 export default {
     viewGroup,
@@ -36,4 +37,5 @@ export default {
     hideAllElements,
     dynamicRows,
     remoteHandler,
+    measureWithAnimations,
 };

--- a/packages/app-harness/src/screens/tests/measureWithAnimations.tsx
+++ b/packages/app-harness/src/screens/tests/measureWithAnimations.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet } from 'react-native';
+import { ScrollView, View, withParentContextMapper, Animated } from '@flexn/create';
+import { getScaledValue } from '@rnv/renative';
+import Screen from '../screen';
+import { Button } from '../../components/Button';
+import { Ratio } from '../../utils';
+
+const AnimatedView = withParentContextMapper(Animated.createAnimatedComponent(View));
+
+const MeasureWithAnimations = () => {
+    const moveAnimation = useRef(new Animated.Value(0)).current;
+
+    useEffect(() => {
+        Animated.timing(moveAnimation, {
+            toValue: 400,
+            duration: 5000,
+            useNativeDriver: false,
+        }).start();
+    }, []);
+
+    const onButton1Press = () => {
+        Animated.timing(moveAnimation, {
+            toValue: 0,
+            duration: 1000,
+            useNativeDriver: false,
+        }).start();
+    };
+
+    return (
+        <Screen style={{ backgroundColor: '#222222' }}>
+            <ScrollView>
+                <View style={{ top: Ratio(20) }}>
+                    <Button
+                        style={{ ...styles.button }}
+                        title="Animate button 2"
+                        textStyle={styles.buttonTextStyle}
+                        onPress={onButton1Press}
+                    />
+                    <AnimatedView
+                        style={{
+                            transform: [{ translateX: moveAnimation }],
+                            // left: moveAnimation,
+                        }}
+                    >
+                        <Button style={{ ...styles.button }} title="Button2" textStyle={styles.buttonTextStyle} />
+                    </AnimatedView>
+                </View>
+            </ScrollView>
+        </Screen>
+    );
+};
+
+const styles = StyleSheet.create({
+    button: {
+        marginHorizontal: getScaledValue(20),
+        borderWidth: getScaledValue(2),
+        borderRadius: getScaledValue(25),
+        borderColor: '#62DBFB',
+        height: getScaledValue(50),
+        width: Ratio(500),
+        marginTop: getScaledValue(20),
+    },
+    buttonTextStyle: {
+        color: '#ffffff',
+        fontSize: Ratio(20),
+    },
+    packshot: {
+        width: Ratio(200),
+        height: Ratio(200),
+        margin: Ratio(5),
+    },
+    image: {
+        width: '100%',
+        height: '100%',
+    },
+    button1Pos: {},
+    button2Pos: {
+        left: Ratio(400),
+    },
+});
+
+MeasureWithAnimations.id = 'MWA1';
+MeasureWithAnimations.platform = ['androidtv', 'firetv', 'tvos', 'tizen', 'webos'];
+MeasureWithAnimations.route = 'MeasureWithAnimations';
+MeasureWithAnimations.title = 'MeasureWithAnimations';
+MeasureWithAnimations.description = '';
+
+export default MeasureWithAnimations;

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flexn/create",
-    "version": "1.1.0-feat.interactions.0",
+    "version": "1.1.0-feat.interactions.1",
     "description": "Flexn Create SDK",
     "main": "lib/index",
     "types": "lib/index",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flexn/create",
-    "version": "1.1.0-alpha.0",
+    "version": "1.1.0-feat.interactions.0",
     "description": "Flexn Create SDK",
     "main": "lib/index",
     "types": "lib/index",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flexn/create",
-    "version": "1.1.0-feat.interactions.1",
+    "version": "1.1.0-alpha.0",
     "description": "Flexn Create SDK",
     "main": "lib/index",
     "types": "lib/index",

--- a/packages/create/src/apis/Animated/index.ts
+++ b/packages/create/src/apis/Animated/index.ts
@@ -1,3 +1,126 @@
 import { Animated } from 'react-native';
+import { measureSync } from '../../focusManager/layoutManager';
+import FocusModel from '../../focusManager/model/abstractFocusModel';
+import CoreManager from '../../focusManager/service/core';
 
-export default Animated;
+type EndResult = { finished: boolean };
+type EndCallback = (result: EndResult) => void;
+
+const onAnimationEnds = () => {
+    Object.values(CoreManager.getViews()).forEach((model: FocusModel) => {
+        if (model.isInForeground()) {
+            measureSync({ model });
+        }
+    });
+};
+
+export const loop = (
+    animation: Animated.CompositeAnimation,
+    config: Animated.LoopAnimationConfig
+): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.loop(animation, config).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.loop(animation, config).stop,
+        reset: Animated.loop(animation, config).reset,
+    };
+};
+
+export const stagger = (time: number, animations: Array<Animated.CompositeAnimation>): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.stagger(time, animations).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.stagger(time, animations).stop,
+        reset: Animated.stagger(time, animations).reset,
+    };
+};
+
+export const parallel = (
+    animations: Array<Animated.CompositeAnimation>,
+    config: Animated.ParallelConfig
+): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.parallel(animations, config).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.parallel(animations, config).stop,
+        reset: Animated.parallel(animations, config).reset,
+    };
+};
+
+export const sequence = (animations: Array<Animated.CompositeAnimation>): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.sequence(animations).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.sequence(animations).stop,
+        reset: Animated.sequence(animations).reset,
+    };
+};
+
+export const spring = (
+    value: Animated.Value | Animated.ValueXY,
+    config: Animated.SpringAnimationConfig
+): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.spring(value, config).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.spring(value, config).stop,
+        reset: Animated.spring(value, config).reset,
+    };
+};
+
+export const decay = (
+    value: Animated.Value | Animated.ValueXY,
+    config: Animated.DecayAnimationConfig
+): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.decay(value, config).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.decay(value, config).stop,
+        reset: Animated.decay(value, config).reset,
+    };
+};
+
+export const timing = (
+    value: Animated.Value | Animated.ValueXY,
+    config: Animated.TimingAnimationConfig
+): Animated.CompositeAnimation => {
+    return {
+        start: (callback?: EndCallback) => {
+            Animated.timing(value, config).start(({ finished }) => {
+                callback?.({ finished });
+                onAnimationEnds();
+            });
+        },
+        stop: Animated.timing(value, config).stop,
+        reset: Animated.timing(value, config).reset,
+    };
+};
+
+export default {
+    ...Animated,
+    timing,
+};

--- a/packages/create/src/components/FlashList/index.tsx
+++ b/packages/create/src/components/FlashList/index.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, useEffect, useRef, useState } from 'react';
+import React, { ForwardedRef, useEffect, useRef, useState, LegacyRef } from 'react';
 import { View as RNView, Platform } from 'react-native';
 import { FlashList as FlashListComp, ListRenderItemInfo, CellContainer } from '@flexn/shopify-flash-list';
 import BaseScrollComponent from '@flexn/recyclerlistview/dist/reactnative/core/scrollcomponent/BaseScrollComponent';
@@ -14,9 +14,9 @@ import { Ratio } from '../../helpers';
 import View from '../../focusManager/model/view';
 import { CoreManager } from '../..';
 
-const FlashList = (props: FlashListProps<any>) => {
+const FlashList = React.forwardRef((props: FlashListProps<any>, ref: LegacyRef<FlashListComp<any>>) => {
     if (!CoreManager.isFocusManagerEnabled()) {
-        return <FlashListComp {...props} />;
+        return <FlashListComp {...props} ref={ref} />;
     }
 
     const {
@@ -205,6 +205,6 @@ const FlashList = (props: FlashListProps<any>) => {
             )}
         </RNView>
     );
-};
+});
 
 export default FlashList;

--- a/packages/create/src/hooks/useOnLayout.ts
+++ b/packages/create/src/hooks/useOnLayout.ts
@@ -23,18 +23,23 @@ export default function useOnLayout(model: FocusModel | null, callback?: (() => 
 
     const onLayout = () => {
         if (interactionPromise.current) {
+            sendOnLayoutEvent();
             interactionPromise.current.then(() => {
-                if (model) {
-                    CoreManager.setPendingLayoutMeasurement(model, () => {
-                        Event.emit(model.getType(), model.getId(), EVENT_TYPES.ON_LAYOUT);
-                        callback?.();
-                    });
-                } else {
-                    callback?.();
-                }
+                sendOnLayoutEvent();
             });
         } else {
             if (callback) pendingCallbacks.push(callback);
+        }
+    };
+
+    const sendOnLayoutEvent = () => {
+        if (model) {
+            CoreManager.setPendingLayoutMeasurement(model, () => {
+                Event.emit(model.getType(), model.getId(), EVENT_TYPES.ON_LAYOUT);
+                callback?.();
+            });
+        } else {
+            callback?.();
         }
     };
 

--- a/packages/create/src/hooks/useOnLayout.ts
+++ b/packages/create/src/hooks/useOnLayout.ts
@@ -1,35 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { InteractionManager } from 'react-native';
 import CoreManager from '../focusManager/service/core';
 import Event, { EVENT_TYPES } from '../focusManager/events';
 import FocusModel from '../focusManager/model/abstractFocusModel';
 
 export default function useOnLayout(model: FocusModel | null, callback?: (() => void) | (() => Promise<void>)) {
-    const interactionPromise = useRef<Promise<any>>();
-    const pendingCallbacks = useRef<{ (): void | Promise<void> }[]>([]).current;
-
     useEffect(() => {
-        interactionPromise.current = InteractionManager.runAfterInteractions(() => {
-            if (pendingCallbacks.length) {
-                for (let index = 0; index < pendingCallbacks.length; index++) {
-                    pendingCallbacks[index]();
-                }
-                pendingCallbacks.splice(0, pendingCallbacks.length);
-            }
-
-            return true;
-        }).then(() => Promise.resolve());
+        InteractionManager.runAfterInteractions(() => {
+            sendOnLayoutEvent();
+        });
     }, []);
 
     const onLayout = () => {
-        if (interactionPromise.current) {
-            sendOnLayoutEvent();
-            interactionPromise.current.then(() => {
-                sendOnLayoutEvent();
-            });
-        } else {
-            if (callback) pendingCallbacks.push(callback);
-        }
+        sendOnLayoutEvent();
     };
 
     const sendOnLayoutEvent = () => {


### PR DESCRIPTION
In some occasions an example when component is being animated using translate properly on layout is not called. For that reason focus manager can't measure element position if it's changed. 

Added animations abstractions in order to capture end of animation moment and remeasure elements.