### PR TITLE
Allow dynamically change focusKey

### DIFF
--- a/packages/create/src/components/Pressable/index.tsx
+++ b/packages/create/src/components/Pressable/index.tsx
@@ -127,6 +127,10 @@ const View = React.forwardRef<RNView | undefined, PressableProps>(
         ]);
 
         useEffect(() => {
+            model.setFocusKey(focusOptions.focusKey);
+        }, [focusOptions.focusKey]);
+
+        useEffect(() => {
             if (focus) {
                 Event.emit(model.getType(), model.getId(), EVENT_TYPES.ON_MOUNT);
             }

--- a/packages/create/src/components/Pressable/index.tsx
+++ b/packages/create/src/components/Pressable/index.tsx
@@ -127,7 +127,9 @@ const View = React.forwardRef<RNView | undefined, PressableProps>(
         ]);
 
         useEffect(() => {
-            model.setFocusKey(focusOptions.focusKey);
+            if (focus) {
+                model.setFocusKey(focusOptions.focusKey);
+            }
         }, [focusOptions.focusKey]);
 
         useEffect(() => {

--- a/packages/create/src/components/Screen/index.tsx
+++ b/packages/create/src/components/Screen/index.tsx
@@ -4,7 +4,6 @@ import type { ScreenProps } from '../../focusManager/types';
 import { useCombinedRefs } from '../../hooks/useCombinedRef';
 import ScreenClass from '../../focusManager/model/screen';
 import useOnLayout from '../../hooks/useOnLayout';
-import Event, { EVENT_TYPES } from '../../focusManager/events';
 import useOnComponentLifeCycle from '../../hooks/useOnComponentLifeCycle';
 import { CoreManager } from '../..';
 
@@ -35,20 +34,21 @@ const Screen = React.forwardRef<RNView | undefined, ScreenProps>(
         useOnComponentLifeCycle({ model });
 
         useEffect(() => {
+            model.setFocusKey(focusOptions.focusKey);
+        }, [focusOptions.focusKey]);
+
+        useEffect(() => {
             if (focusOptions.screenState) {
-                Event.emit(model.getType(), model.getId(), EVENT_TYPES.ON_PROPERTY_CHANGED, {
-                    property: 'state',
-                    newValue: focusOptions.screenState,
-                });
+                model.setPrevState(model.getState()).setState(focusOptions.screenState);
+                if (model.isPrevStateBackground() && model.isInForeground()) {
+                    model.setFocus(model.getFirstFocusableOnScreen());
+                }
             }
         }, [focusOptions.screenState]);
 
         useEffect(() => {
             if (focusOptions.screenOrder !== undefined) {
-                Event.emit(model.getType(), model.getId(), EVENT_TYPES.ON_PROPERTY_CHANGED, {
-                    property: 'order',
-                    newValue: focusOptions.screenOrder,
-                });
+                model.setOrder(focusOptions.screenOrder);
             }
         }, [focusOptions.screenOrder]);
 

--- a/packages/create/src/components/ViewGroup/index.tsx
+++ b/packages/create/src/components/ViewGroup/index.tsx
@@ -30,6 +30,10 @@ const ViewGroup = React.forwardRef<View, ViewGroupProps>(
             model.setGroup(focusOptions.group);
         }, [focusOptions.group]);
 
+        useEffect(() => {
+            model.setFocusKey(focusOptions.focusKey);
+        }, [focusOptions.focusKey]);
+
         const { onLayout } = useOnLayout(model);
 
         const childrenWithProps = React.Children.map(children, (child) => {

--- a/packages/create/src/focusManager/events.ts
+++ b/packages/create/src/focusManager/events.ts
@@ -1,5 +1,4 @@
 export const EVENT_TYPES = {
-    ON_PROPERTY_CHANGED: 'onPropertyChanged',
     ON_MOUNT: 'onMount',
     ON_MOUNT_AND_MEASURED: 'onMountAndMeasured',
     ON_UNMOUNT: 'onUnMount',

--- a/packages/create/src/focusManager/model/view.ts
+++ b/packages/create/src/focusManager/model/view.ts
@@ -23,7 +23,7 @@ class View extends FocusModel {
     private _parentScrollView?: ScrollView;
 
     private _isFocused: boolean;
-    private _focusKey: string;
+    private _focusKey?: string;
     private _hasPreferredFocus: boolean;
     private _verticalContentContainerGap = 0;
     private _horizontalContentContainerGap = 0;
@@ -51,7 +51,7 @@ class View extends FocusModel {
             onFocus,
             onBlur,
             onPress,
-            focusKey = '',
+            focusKey,
             hasPreferredFocus = false,
             verticalContentContainerGap = 0,
             horizontalContentContainerGap = 0,
@@ -214,8 +214,14 @@ class View extends FocusModel {
         return this._repeatContext;
     }
 
-    public getFocusKey(): string {
+    public getFocusKey(): string | undefined {
         return this._focusKey;
+    }
+
+    public setFocusKey(value?: string): this {
+        this._focusKey = value;
+
+        return this;
     }
 
     public hasPreferredFocus(): boolean {

--- a/packages/create/src/focusManager/model/viewGroup.ts
+++ b/packages/create/src/focusManager/model/viewGroup.ts
@@ -58,8 +58,14 @@ class ViewGroup extends FocusModel {
         return this;
     }
 
-    public getFocusKey() {
+    public getFocusKey(): string | undefined {
         return this._focusKey;
+    }
+
+    public setFocusKey(value?: string): this {
+        this._focusKey = value;
+
+        return this;
     }
 
     public getNode(): MutableRefObject<View> {


### PR DESCRIPTION
Until now `focusOptions.focusKey` property was static and initialised on component load. However we noticed that there's a need to have this property updatable in some situations. This PR makes focusKey be dynamic property.

Related issue #162 