### PR TITLE
Focus and Blur events for FlashList

### DIFF
--- a/packages/app-harness/src/components/FocusedElementSelector/index.tsx
+++ b/packages/app-harness/src/components/FocusedElementSelector/index.tsx
@@ -5,7 +5,7 @@ import { useDebugContext } from '../../context/debugContext';
 import { Ratio, testProps } from '../../utils';
 
 const FocusedElementSelector = () => {
-    const { focusedElementId } = useDebugContext();
+    const { focusedElementId, additionalTextInfo } = useDebugContext();
 
     if (focusedElementId) {
         return (
@@ -13,6 +13,25 @@ const FocusedElementSelector = () => {
                 <Text {...testProps('focused-element-selector')} style={styles.title}>
                     {focusedElementId}
                 </Text>
+                {additionalTextInfo[0] !== '' && (
+                    <View style={{ flexDirection: 'row' }}>
+                        <Text {...testProps('additional-text-info-selector-0')} style={styles.title}>
+                            {additionalTextInfo[0]}
+                        </Text>
+                        <Text>{` `}</Text>
+                        {additionalTextInfo[1] !== '' && (
+                            <Text {...testProps('additional-text-info-selector-1')} style={styles.title}>
+                                {additionalTextInfo[1]}
+                            </Text>
+                        )}
+                        <Text>{` `}</Text>
+                        {additionalTextInfo[2] !== '' && (
+                            <Text {...testProps('additional-text-info-selector-2')} style={styles.title}>
+                                {additionalTextInfo[2]}
+                            </Text>
+                        )}
+                    </View>
+                )}
             </View>
         );
     }

--- a/packages/app-harness/src/context/debugContext.tsx
+++ b/packages/app-harness/src/context/debugContext.tsx
@@ -2,20 +2,33 @@ import React, { createContext, useContext, useState, Dispatch, SetStateAction } 
 
 export interface ConfigInterface {
     focusedElementId: string;
+    additionalTextInfo: string[];
     setFocusedElementId: Dispatch<SetStateAction<string>>;
+    setAdditionalTextInfo: Dispatch<SetStateAction<string[]>>;
 }
 
 export const DebugContext = createContext<ConfigInterface>({
     focusedElementId: '',
+    additionalTextInfo: [],
     setFocusedElementId: () => {
+        // void
+    },
+    setAdditionalTextInfo: () => {
         // void
     },
 });
 
 export function DebugProvider({ children }: { children: any }) {
     const [focusedElementId, setFocusedElementId] = useState('');
+    const [additionalTextInfo, setAdditionalTextInfo] = useState(['']);
 
-    return <DebugContext.Provider value={{ focusedElementId, setFocusedElementId }}>{children}</DebugContext.Provider>;
+    return (
+        <DebugContext.Provider
+            value={{ focusedElementId, additionalTextInfo, setFocusedElementId, setAdditionalTextInfo }}
+        >
+            {children}
+        </DebugContext.Provider>
+    );
 }
 
 export function useDebugContext() {

--- a/packages/app-harness/src/screens/tests/index.ts
+++ b/packages/app-harness/src/screens/tests/index.ts
@@ -20,6 +20,7 @@ import measureWithAnimations from './measureWithAnimations';
 import setFocus from './setFocus';
 import nextFocus from './nextFocus';
 import preferredFocus from './preferredFocus';
+import rowOnFocusBlur from './rowOnFocusBlur';
 
 export default {
     viewGroup,
@@ -44,4 +45,5 @@ export default {
     setFocus,
     nextFocus,
     preferredFocus,
+    rowOnFocusBlur,
 };

--- a/packages/app-harness/src/screens/tests/rowOnFocusBlur.tsx
+++ b/packages/app-harness/src/screens/tests/rowOnFocusBlur.tsx
@@ -5,6 +5,7 @@ import type { NavigationProps } from '../../navigation';
 import Screen from './../screen';
 import { Ratio } from '../../utils';
 import Pressable from '../../components/Pressable';
+import { useDebugContext } from '../../context/debugContext';
 
 const kittyNames = ['Abby', 'Angel', 'Annie', 'Baby', 'Bailey', 'Bandit'];
 
@@ -26,6 +27,9 @@ function generateData(width: number, height: number, items = 30) {
 }
 
 const RowOnFocusBlur = ({ route }: NavigationProps) => {
+    const { setAdditionalTextInfo } = useDebugContext();
+    const [focusTimesInRow, setFocusTimesInRow] = useState<Record<number, number>>({ 0: 0 });
+    const [blurTimesInRow, setBlurTimesInRow] = useState<Record<number, number>>({ 0: 0 });
     const [list] = useState(Array(10).fill(generateData(Ratio(200), Ratio(200), 10)));
 
     const rowRenderer = ({
@@ -70,10 +74,14 @@ const RowOnFocusBlur = ({ route }: NavigationProps) => {
                             estimatedItemSize={Ratio(200)}
                             style={{ flex: 1, marginVertical: Ratio(10) }}
                             onFocus={() => {
-                                console.log(`Row ${index} focused`);
+                                const next = (focusTimesInRow[index] ? focusTimesInRow[index] : 0) + 1;
+                                setFocusTimesInRow((prev) => ({ ...prev, [index]: next }));
+                                setAdditionalTextInfo((prev) => [`Row ${index} focused ${next}`, prev[1]]);
                             }}
                             onBlur={() => {
-                                console.log(`Row ${index} blurred`);
+                                const next = (blurTimesInRow[index] ? blurTimesInRow[index] : 0) + 1;
+                                setBlurTimesInRow((prev) => ({ ...prev, [index]: next }));
+                                setAdditionalTextInfo((prev) => [prev[0], `Row ${index} blurred ${next}`]);
                             }}
                         />
                     ))}
@@ -103,6 +111,6 @@ RowOnFocusBlur.platform = ['androidtv', 'firetv', 'tvos', 'tizen', 'webos'];
 RowOnFocusBlur.route = 'RowOnFocusBlur';
 RowOnFocusBlur.title = 'RowOnFocusBlur';
 RowOnFocusBlur.description =
-    "List component where focus should be predictable and every row has to remember it's position. Also any focused item should never be hidden.";
+    'There is multiple rows and when focus is inside of row you should see row id above and amount of times if was focused. Same if you leave there row there is indication about blur event';
 
 export default RowOnFocusBlur;

--- a/packages/app-harness/src/screens/tests/rowOnFocusBlur.tsx
+++ b/packages/app-harness/src/screens/tests/rowOnFocusBlur.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { View, FlashList, Image, ScrollView, CreateListRenderItemInfo } from '@flexn/create';
+import type { NavigationProps } from '../../navigation';
+import Screen from './../screen';
+import { Ratio } from '../../utils';
+import Pressable from '../../components/Pressable';
+
+const kittyNames = ['Abby', 'Angel', 'Annie', 'Baby', 'Bailey', 'Bandit'];
+
+function interval(min = 0, max = kittyNames.length - 1) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+function generateData(width: number, height: number, items = 30) {
+    const temp: any = [];
+    for (let index = 0; index < items; index++) {
+        temp.push({
+            index,
+            backgroundImage: `https://placekitten.com/${width + index}/${height}`,
+            title: `${kittyNames[interval()]} ${kittyNames[interval()]} ${kittyNames[interval()]}`,
+        });
+    }
+
+    return temp;
+}
+
+const RowOnFocusBlur = ({ route }: NavigationProps) => {
+    const [list] = useState(Array(10).fill(generateData(Ratio(200), Ratio(200), 10)));
+
+    const rowRenderer = ({
+        item,
+        focusRepeatContext,
+        index,
+        listIndex,
+    }: CreateListRenderItemInfo<any> & { listIndex: number }) => {
+        return (
+            <Pressable
+                style={styles.packshot}
+                focusRepeatContext={focusRepeatContext}
+                focusOptions={{
+                    animator: {
+                        type: 'border',
+                        focus: {
+                            borderWidth: Ratio(8),
+                            borderColor: 'blue',
+                        },
+                    },
+                }}
+                testID={`L1-${listIndex}-${index}`}
+            >
+                <Image source={{ uri: item.backgroundImage }} style={styles.image} />
+            </Pressable>
+        );
+    };
+
+    return (
+        <Screen style={{ backgroundColor: '#222222' }} route={route}>
+            <ScrollView>
+                <View style={{ top: 20, flex: 1, paddingBottom: 20 }}>
+                    {list.map((listData, index) => (
+                        <FlashList
+                            key={index}
+                            data={listData}
+                            renderItem={(props) => {
+                                return rowRenderer({ ...props, listIndex: index });
+                            }}
+                            horizontal
+                            type="row"
+                            estimatedItemSize={Ratio(200)}
+                            style={{ flex: 1, marginVertical: Ratio(10) }}
+                            onFocus={() => {
+                                console.log(`Row ${index} focused`);
+                            }}
+                            onBlur={() => {
+                                console.log(`Row ${index} blurred`);
+                            }}
+                        />
+                    ))}
+                </View>
+            </ScrollView>
+        </Screen>
+    );
+};
+
+const styles = StyleSheet.create({
+    packshot: {
+        width: Ratio(200),
+        height: Ratio(200),
+        // borderColor: 'red',
+        // borderWidth: 1,
+        margin: Ratio(5),
+        // borderWidth: 2,
+    },
+    image: {
+        width: '100%',
+        height: '100%',
+    },
+});
+
+RowOnFocusBlur.id = 'RFB1';
+RowOnFocusBlur.platform = ['androidtv', 'firetv', 'tvos', 'tizen', 'webos'];
+RowOnFocusBlur.route = 'RowOnFocusBlur';
+RowOnFocusBlur.title = 'RowOnFocusBlur';
+RowOnFocusBlur.description =
+    "List component where focus should be predictable and every row has to remember it's position. Also any focused item should never be hidden.";
+
+export default RowOnFocusBlur;

--- a/packages/create/src/components/FlashList/index.tsx
+++ b/packages/create/src/components/FlashList/index.tsx
@@ -70,6 +70,13 @@ const FlashList = React.forwardRef((props: FlashListProps<any>, ref: LegacyRef<F
     const { onLayout } = useOnLayout(model);
 
     useEffect(() => {
+        model?.updateEvents?.({
+            onFocus,
+            onBlur,
+        });
+    }, [onFocus, onBlur]);
+
+    useEffect(() => {
         const unsubscribe = Event.subscribe(
             model.getType(),
             model.getId(),

--- a/packages/create/src/focusManager/model/recycler.ts
+++ b/packages/create/src/focusManager/model/recycler.ts
@@ -234,6 +234,13 @@ class RecyclerView extends FocusModel {
     public getNode(): MutableRefObject<ScrollView> {
         return this.node;
     }
+
+    public updateEvents({ onFocus, onBlur }: { onPress?(): void; onFocus?(): void; onBlur?(): void }) {
+        this._onFocus = onFocus;
+        this._onBlur = onBlur;
+
+        return this;
+    }
 }
 
 export default RecyclerView;

--- a/packages/create/src/focusManager/model/row.ts
+++ b/packages/create/src/focusManager/model/row.ts
@@ -69,7 +69,7 @@ class Row extends Recycler {
 
             return Core.getNextFocusableContext(direction, candidates, false);
         } else if (!this._isInBounds(direction) || isVertical) {
-            const nextFocus = Core.getNextFocusableContext(direction);
+            const nextFocus = Core.getNextFocusableContext(direction, undefined, false);
 
             if (
                 isHorizontal &&
@@ -79,7 +79,7 @@ class Row extends Recycler {
                 return Core.getCurrentFocus();
             }
 
-            return nextFocus;
+            return Core.getNextFocusableContext(direction);
         }
 
         return null;

--- a/packages/create/src/focusManager/model/screen.ts
+++ b/packages/create/src/focusManager/model/screen.ts
@@ -154,7 +154,7 @@ class Screen extends FocusModel {
             setTimeout(() => {
                 delete this._componentsPendingLayoutMap[id];
 
-                if (Object.keys(this._componentsPendingLayoutMap).length <= 0) {
+                if (Object.keys(this._componentsPendingLayoutMap).length <= 0 && this._initialLoadInProgress) {
                     this._initialLoadInProgress = false;
                     if (this._stealFocus) {
                         this.setFocus(this.getFirstFocusableOnScreen());

--- a/packages/create/src/focusManager/service/core.ts
+++ b/packages/create/src/focusManager/service/core.ts
@@ -228,8 +228,10 @@ class CoreManager {
                     return currentFocus;
                 }
 
-                currentFocus.getParent()?.onBlur();
-                closestView.getParent()?.onFocus();
+                if (findFocusInParent) {
+                    currentFocus.getParent()?.onBlur();
+                    closestView.getParent()?.onFocus();
+                }
 
                 if (closestView.getParent()?.getType() === MODEL_TYPES.ROW) {
                     const parent = closestView.getParent();
@@ -238,8 +240,10 @@ class CoreManager {
             }
 
             if (closestView.getScreen()?.getId() !== currentFocus.getScreen()?.getId()) {
-                currentFocus.getScreen()?.onBlur?.();
-                closestView.getScreen()?.onFocus?.();
+                if (findFocusInParent) {
+                    currentFocus.getScreen()?.onBlur?.();
+                    closestView.getScreen()?.onFocus?.();
+                }
 
                 if (closestView.getScreen()?.getCurrentFocus()) {
                     return closestView.getScreen()!.getCurrentFocus();


### PR DESCRIPTION
Until now we had onFocus and onBlur events working on Pressable and Screen components. This PR adds same events for FlashList. If your focus will go on any item in FlashList you will get onFocus event fired only once. At the same time onBlur will be send once you navigate out of items from FlashList.

Related ticket #169 